### PR TITLE
UI improvement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Simplified the mobile board header into a single top row. On Samsung S23-sized screens the visible header now stays to logo or board name plus notifications and menu, while search and account or sync controls open in the mobile menu overlay instead of stacking across three persistent rows.
+
 ### Fixed
 
 - ci fix

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added per-column WIP limits. Each column carries a `wipLimit` (0 = unlimited) set in the Add Column and Edit Column modals. The column header counter shows `count/limit`, turning amber at the limit and red above it, and the column itself takes a coloured top edge so the state stays readable when the header is collapsed or squeezed on mobile. Limits are advisory and never block adding, dragging, importing, or syncing a task: under event-sourced sync a remote event cannot be rejected without breaking convergence, so a hard block would be a guarantee the sync model cannot keep. The Done column is exempt, counts are measured board-wide across swimlanes, and limits ride the existing `column.updated` event with no new event type.
+
 ### Changed
 
 - Simplified the mobile board header into a single top row. On Samsung S23-sized screens the visible header now stays to logo or board name plus notifications and menu, while search and account or sync controls open in the mobile menu overlay instead of stacking across three persistent rows.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Simplified the mobile board header into a single top row. On Samsung S23-sized screens the visible header now stays to logo or board name plus notifications and menu, while search and account or sync controls open in the mobile menu overlay instead of stacking across three persistent rows.
+- Expanded the mobile controls menu into a full-screen overlay with an explicit close button so the search field, sync or account status, and board actions open at the top of the viewport instead of starting far down the screen.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - ci fix
+- Fixed Online Mode losing some boards across devices after local snapshots. Board snapshots now only consider and garbage-collect events from their own board scope, so one board's snapshot cannot erase unsynced history for other boards before it reaches PocketBase.
+- Fixed the legacy full-pull sync helper leaving pulled boards invisible locally by merging remote board rows into the local board list before returning.
 
 ## [3.0.8] - 2026-08-31
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -10,6 +10,24 @@
 All canonical factory functions live in `client/src/modules/schema.js`. Every new entity must be
 constructed through those factories so all fields are always present.
 
+### Glossary
+
+**WIP limit** — the maximum number of Tasks a Column is *intended* to hold, stored as `wipLimit` on
+the Column. `0` means unlimited (the default; built-in templates ship unlimited). A WIP limit is
+**advisory, never enforced**: nothing blocks adding, dragging, importing, or syncing a Task into a
+Column that is at or over its limit. It is a pull-system signal — reaching the limit means *stop
+starting, start finishing* — surfaced only as a visual state on the board.
+
+> **Why advisory and not a hard block.** Under event-sourced sync ([ADR-0004](docs/adr/0004-event-sourced-sync.md))
+> a remote `task.created` / `task.moved` event arriving over SSE cannot be rejected without breaking
+> convergence. Two devices offline can each add the 5th Task to a limit-5 Column and legitimately
+> converge at 6. A limit enforced only on the local device would be a guarantee the sync model
+> cannot keep, so it is not offered as one.
+
+**At limit / over limit** — the two breach states. *At limit* is `taskCount === wipLimit`; *over
+limit* is `taskCount > wipLimit`. A Column's count is measured **board-wide across all swimlanes**,
+not per lane×column cell — a WIP limit constrains system capacity, not each lane's. The **Done**
+Column is exempt: it is terminal and unbounded, and limiting it would block finishing work.
 
 ---
 

--- a/client/src/index.html
+++ b/client/src/index.html
@@ -36,6 +36,12 @@
       </div>
 
       <div id="board-controls-menu" class="controls-actions">
+        <div class="controls-menu-mobile-header">
+          <span class="controls-menu-mobile-title">Board controls</span>
+          <button id="mobile-menu-close-btn" class="icon-btn controls-menu-close-btn" type="button" aria-label="Close controls">
+            <span data-lucide="x" aria-hidden="true"></span>
+          </button>
+        </div>
         <label class="sr-only" for="board-select">Select board</label>
         <select id="board-select" class="control-select" aria-label="Select board"></select>
         <label class="control-btn swimlane-toggle-label" for="swimlane-quick-toggle">

--- a/client/src/index.html
+++ b/client/src/index.html
@@ -91,28 +91,32 @@
         </a>
       </div>
       
-      <button id="login-btn" class="control-btn" type="button" aria-haspopup="dialog" aria-label="Sign in to sync">
-        <span data-lucide="cloud" aria-hidden="true"></span>
-        <span>Go Online</span>
-      </button>
-
-      <div id="user-info" class="user-info hidden" aria-label="Signed-in user">
-        <span id="user-name" class="user-name" aria-live="polite"></span>
-        <button id="logout-btn" class="control-btn icon-only" type="button" aria-label="Sign out">
-          <span data-lucide="log-out" aria-hidden="true"></span>
+      <div class="session-status" aria-label="Session status">
+        <button id="login-btn" class="control-btn" type="button" aria-haspopup="dialog" aria-label="Sign in to sync">
+          <span data-lucide="cloud" aria-hidden="true"></span>
+          <span>Go Online</span>
         </button>
+
+        <div id="user-info" class="user-info hidden" aria-label="Signed-in user">
+          <span id="user-name" class="user-name" aria-live="polite"></span>
+          <button id="logout-btn" class="control-btn icon-only" type="button" aria-label="Sign out">
+            <span data-lucide="log-out" aria-hidden="true"></span>
+          </button>
+        </div>
+
+        <span id="sync-indicator" class="sync-indicator sync-indicator--offline" role="status" aria-live="polite" aria-label="Sync state">Offline</span>
       </div>
 
-      <span id="sync-indicator" class="sync-indicator sync-indicator--offline" role="status" aria-live="polite" aria-label="Sync state">Offline</span>
+      <div class="toolbar-quick-actions">
+        <button id="notifications-quick-btn" class="control-btn icon-only" type="button" aria-haspopup="dialog" aria-label="Notifications">
+          <span data-lucide="bell" aria-hidden="true"></span>
+          <span id="notification-quick-badge" class="notification-badge hidden" aria-label="notifications count"></span>
+        </button>
 
-      <button id="notifications-quick-btn" class="control-btn icon-only" type="button" aria-haspopup="dialog" aria-label="Notifications">
-        <span data-lucide="bell" aria-hidden="true"></span>
-        <span id="notification-quick-badge" class="notification-badge hidden" aria-label="notifications count"></span>
-      </button>
-
-      <button id="desktop-menu-btn" class="control-btn icon-only" type="button" aria-label="Menu" aria-expanded="false" aria-controls="board-controls-menu">
-        <span data-lucide="ellipsis-vertical" aria-hidden="true"></span>
-      </button>
+        <button id="desktop-menu-btn" class="control-btn icon-only" type="button" aria-label="Menu" aria-expanded="false" aria-controls="board-controls-menu">
+          <span data-lucide="ellipsis-vertical" aria-hidden="true"></span>
+        </button>
+      </div>
       
       <input type="file" id="import-file" accept="application/json" class="sr-only" aria-label="Import board file">
     </nav>

--- a/client/src/index.html
+++ b/client/src/index.html
@@ -277,6 +277,11 @@
             <input type="text" id="column-color-hex" class="color-hex-display" value="#3b82f6" maxlength="7" spellcheck="false" aria-label="Hex color code">
           </div>
         </div>
+        <div class="form-group" id="column-wip-limit-group">
+          <label for="column-wip-limit">WIP Limit</label>
+          <input type="number" id="column-wip-limit" min="0" max="999" step="1" value="0" inputmode="numeric" placeholder="0" aria-describedby="column-wip-limit-hint">
+          <small id="column-wip-limit-hint" class="form-hint">0 = unlimited. The board shows a warning at the limit and a breach above it &mdash; tasks are never blocked.</small>
+        </div>
         <div class="form-actions">
           <button type="button" id="cancel-column-btn" class="btn btn-secondary">Cancel</button>
           <button type="submit" id="column-submit-btn" class="btn btn-primary">Add Column</button>

--- a/client/src/kanban.js
+++ b/client/src/kanban.js
@@ -90,8 +90,15 @@ document.addEventListener('DOMContentLoaded', async () => {
   // Mobile Menu Logic
   const menuBtn = document.getElementById('desktop-menu-btn');
   const controlsActions = document.getElementById('board-controls-menu');
+  const controls = document.querySelector('.controls');
 
   if (menuBtn && controlsActions) {
+    const closeMenu = () => {
+      controlsActions.classList.remove('show');
+      menuBtn.setAttribute('aria-expanded', 'false');
+      controls?.classList.remove('mobile-menu-open');
+    };
+
     menuBtn.addEventListener('click', (e) => {
       e.stopPropagation();
       const isExpanded = menuBtn.getAttribute('aria-expanded') === 'true';
@@ -99,9 +106,15 @@ document.addEventListener('DOMContentLoaded', async () => {
       // Toggle menu
       controlsActions.classList.toggle('show');
       menuBtn.setAttribute('aria-expanded', String(!isExpanded));
+      controls?.classList.toggle('mobile-menu-open', !isExpanded);
       
       // Close other menus if open (optional, but good practice)
       document.querySelectorAll('.column-menu').forEach(m => m.classList.add('hidden'));
+
+      if (!isExpanded) {
+        boardSearchInput?.focus();
+        boardSearchInput?.select();
+      }
     });
 
     // Close menu when clicking action buttons inside it.
@@ -112,15 +125,20 @@ document.addEventListener('DOMContentLoaded', async () => {
       const isAction = e.target.closest('button, a, [role="menuitem"]');
       if (!isAction) return;
 
-      controlsActions.classList.remove('show');
-      menuBtn.setAttribute('aria-expanded', 'false');
+      closeMenu();
     });
 
     // Close menu when clicking outside
     document.addEventListener('click', (e) => {
       if (!controlsActions.contains(e.target) && !menuBtn.contains(e.target)) {
-        controlsActions.classList.remove('show');
-        menuBtn.setAttribute('aria-expanded', 'false');
+        closeMenu();
+      }
+    });
+
+    boardSearchInput?.addEventListener('keydown', (e) => {
+      if (e.key === 'Escape') {
+        closeMenu();
+        menuBtn.focus();
       }
     });
   }

--- a/client/src/kanban.js
+++ b/client/src/kanban.js
@@ -91,12 +91,14 @@ document.addEventListener('DOMContentLoaded', async () => {
   const menuBtn = document.getElementById('desktop-menu-btn');
   const controlsActions = document.getElementById('board-controls-menu');
   const controls = document.querySelector('.controls');
+  const mobileMenuCloseBtn = document.getElementById('mobile-menu-close-btn');
 
   if (menuBtn && controlsActions) {
     const closeMenu = () => {
       controlsActions.classList.remove('show');
       menuBtn.setAttribute('aria-expanded', 'false');
       controls?.classList.remove('mobile-menu-open');
+      document.body.classList.remove('mobile-menu-open');
     };
 
     menuBtn.addEventListener('click', (e) => {
@@ -107,6 +109,7 @@ document.addEventListener('DOMContentLoaded', async () => {
       controlsActions.classList.toggle('show');
       menuBtn.setAttribute('aria-expanded', String(!isExpanded));
       controls?.classList.toggle('mobile-menu-open', !isExpanded);
+      document.body.classList.toggle('mobile-menu-open', !isExpanded);
       
       // Close other menus if open (optional, but good practice)
       document.querySelectorAll('.column-menu').forEach(m => m.classList.add('hidden'));
@@ -133,6 +136,11 @@ document.addEventListener('DOMContentLoaded', async () => {
       if (!controlsActions.contains(e.target) && !menuBtn.contains(e.target)) {
         closeMenu();
       }
+    });
+
+    mobileMenuCloseBtn?.addEventListener('click', () => {
+      closeMenu();
+      menuBtn.focus();
     });
 
     boardSearchInput?.addEventListener('keydown', (e) => {

--- a/client/src/modules/board-serializer.js
+++ b/client/src/modules/board-serializer.js
@@ -9,6 +9,7 @@ import {
   normalizeRelationships,
   normalizeStringKeys,
 } from './normalize.js';
+import { normalizeWipLimit } from './wip-limit.js';
 
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
@@ -78,6 +79,7 @@ export function normalizeBoardModelIds({ board = null, columns = [], tasks = [],
       name: typeof source.name === 'string' && source.name.trim() ? source.name.trim() : (done ? 'Done' : 'Untitled column'),
       color: isHexColor(source.color) ? source.color.trim() : defaultColumnColor(done ? DONE_COLUMN_ID : source.id),
       collapsed: source.collapsed === true,
+      wipLimit: normalizeWipLimit(source.wipLimit),
       ...(Number.isFinite(source.order) ? { order: source.order } : {}),
       ...(done ? { role: DONE_COLUMN_ROLE } : {})
     };
@@ -85,7 +87,7 @@ export function normalizeBoardModelIds({ board = null, columns = [], tasks = [],
 
   if (!normalizedColumns.some((column) => column.role === DONE_COLUMN_ROLE)) {
     const maxOrder = normalizedColumns.reduce((max, column) => Math.max(max, Number.isFinite(column?.order) ? column.order : 0), 0);
-    normalizedColumns.push({ id: generateUUID(), name: 'Done', color: '#16a34a', order: maxOrder + 1, collapsed: false, role: DONE_COLUMN_ROLE });
+    normalizedColumns.push({ id: generateUUID(), name: 'Done', color: '#16a34a', order: maxOrder + 1, collapsed: false, wipLimit: 0, role: DONE_COLUMN_ROLE });
   }
 
   const fallbackColumnId = normalizedColumns.find((column) => column.role !== DONE_COLUMN_ROLE)?.id || normalizedColumns[0]?.id || '';

--- a/client/src/modules/column-element.js
+++ b/client/src/modules/column-element.js
@@ -7,6 +7,7 @@ import { confirmDialog, alertDialog } from './dialog.js';
 import { PRIORITY_ORDER } from './constants.js';
 import { emit, DATA_CHANGED } from './events.js';
 import { h, cx } from './dom.js';
+import { formatWipCount, getWipState, wipCounterLabel, applyWipCounter } from './wip-limit.js';
 
 function getTaskCountInColumn(columnId) {
   const tasks = loadTasks();
@@ -86,16 +87,18 @@ export function createColumnElement(column) {
     h('span', { 'data-lucide': 'grip-vertical', 'aria-hidden': 'true' })
   );
 
+  const taskCount = getTaskCountInColumn(column.id);
   const titleText = isCollapsed
-    ? `${column.name} (${getTaskCountInColumn(column.id)})`
+    ? `${column.name} (${formatWipCount(taskCount, column)})`
     : column.name;
   const columnTitle = h('h2', { id: `column-title-${column.id}` }, titleText);
 
   const taskCounter = h('span', {
     class: cx('task-counter', isCollapsed && 'hidden'),
     'data-column-id': column.id,
-    'aria-label': 'Task count'
-  }, '0');
+    'aria-label': wipCounterLabel(taskCount, column)
+  });
+  applyWipCounter(taskCounter, taskCount, column);
 
   const addBtn = h('button', {
     class: 'add-task-btn-icon',
@@ -258,6 +261,7 @@ export function createColumnElement(column) {
   return h('article', {
     class: cx('task-column', isCollapsed && 'is-collapsed'),
     'data-column': column.id,
+    'data-wip': getWipState(taskCount, column),
     draggable: 'false',
     'aria-labelledby': `column-title-${column.id}`,
     style: column?.color ? { '--column-accent': column.color } : {}

--- a/client/src/modules/column-modal.js
+++ b/client/src/modules/column-modal.js
@@ -2,6 +2,8 @@
 
 import { loadColumns } from './storage.js';
 import { addColumn, updateColumn } from './columns.js';
+import { isDoneColumn } from './constants.js';
+import { normalizeWipLimit } from './wip-limit.js';
 import { alertDialog } from './dialog.js';
 import { validateAndShowColumnNameError, clearFieldError } from './validation.js';
 import { emit, DATA_CHANGED } from './events.js';
@@ -13,6 +15,17 @@ const HEX_COLOR_RE = /^#[0-9a-fA-F]{6}$/;
 
 function isValidHexColor(value) {
   return HEX_COLOR_RE.test(value);
+}
+
+function setWipLimitField(column) {
+  const group = $id('column-wip-limit-group');
+  const input = $id('column-wip-limit');
+  if (!group || !input) return;
+
+  const exempt = column ? isDoneColumn(column) : false;
+  group.classList.toggle('hidden', exempt);
+  input.disabled = exempt;
+  input.value = String(exempt ? 0 : normalizeWipLimit(column?.wipLimit));
 }
 
 function updateColumnColorHex(color) {
@@ -39,6 +52,7 @@ export function showColumnModal() {
     columnColor.value = '#3b82f6';
     updateColumnColorHex('#3b82f6');
   }
+  setWipLimitField(null);
   modal.classList.remove('hidden');
   columnName.focus();
 }
@@ -65,6 +79,7 @@ export function showEditColumnModal(columnId) {
     columnColor.value = color;
     updateColumnColorHex(color);
   }
+  setWipLimitField(column);
   modal.classList.remove('hidden');
   columnName.focus();
 }
@@ -104,10 +119,12 @@ export function initializeColumnModalHandlers(setupModalCloseHandlers) {
       color = $id('column-color')?.value;
     }
 
+    const wipLimit = normalizeWipLimit($id('column-wip-limit')?.value);
+
     if (editingColumnId) {
-      updateColumn(editingColumnId, name, color);
+      updateColumn(editingColumnId, name, color, wipLimit);
     } else {
-      addColumn(name, color);
+      addColumn(name, color, wipLimit);
     }
     hideColumnModal();
     emit(DATA_CHANGED);

--- a/client/src/modules/columns.js
+++ b/client/src/modules/columns.js
@@ -1,16 +1,17 @@
 import { generateUUID } from './utils.js';
 import { getActiveBoardId, isDoneColumnId, loadColumns, loadTasks } from './storage.js';
 import { normalizeHexColor } from './normalize.js';
+import { normalizeWipLimit } from './wip-limit.js';
 import { scheduleDomainEvent } from './event-sourcing/emitter.js';
 
 // Add a new column
-export function addColumn(name, color) {
+export function addColumn(name, color, wipLimit = 0) {
   if (!name || name.trim() === '') return;
   
   const columns = loadColumns();
   const maxOrder = columns.reduce((max, c) => Math.max(max, c.order ?? 0), 0);
   const id = generateUUID();
-  const newColumn = { id, name: name.trim(), color: normalizeHexColor(color), order: maxOrder - 1, collapsed: false };
+  const newColumn = { id, name: name.trim(), color: normalizeHexColor(color), order: maxOrder - 1, collapsed: false, wipLimit: normalizeWipLimit(wipLimit) };
   columns.push(newColumn);
   scheduleDomainEvent({
     type: 'column.created',
@@ -39,7 +40,7 @@ export function toggleColumnCollapsed(columnId) {
 }
 
 // Update an existing column
-export function updateColumn(columnId, name, color) {
+export function updateColumn(columnId, name, color, wipLimit) {
   if (!name || name.trim() === '') return;
   
   const columns = loadColumns();
@@ -48,11 +49,20 @@ export function updateColumn(columnId, name, color) {
     const previousName = columns[columnIndex].name;
     columns[columnIndex].name = name.trim();
     columns[columnIndex].color = normalizeHexColor(color);
+    columns[columnIndex].wipLimit = normalizeWipLimit(
+      wipLimit === undefined ? columns[columnIndex].wipLimit : wipLimit
+    );
     scheduleDomainEvent({
       type: 'column.updated',
       boardId: getActiveBoardId(),
       entityId: columnId,
-      payload: { fields: { name: columns[columnIndex].name, color: columns[columnIndex].color } }
+      payload: {
+        fields: {
+          name: columns[columnIndex].name,
+          color: columns[columnIndex].color,
+          wipLimit: columns[columnIndex].wipLimit
+        }
+      }
     });
   }
 }

--- a/client/src/modules/event-sourcing/snapshot.js
+++ b/client/src/modules/event-sourcing/snapshot.js
@@ -11,6 +11,12 @@ const _pendingSnapshots = new Map();
 let _getJitter = () => Math.floor(Math.random() * (MAX_JITTER_MS + 1));
 let _afterSnapshotSaved = null;
 
+function eventMatchesSnapshotScope(key, event) {
+  if (!event || typeof event !== 'object') return false;
+  if (key === GLOBAL_SNAPSHOT_KEY) return event.scope === 'global';
+  return (event.scope ?? 'board') === 'board' && event.board_id === key;
+}
+
 export function serializeState(state) {
   return {
     boards: Array.isArray(state.boards) ? state.boards : [],
@@ -46,12 +52,12 @@ export async function loadSnapshot(key) {
   return { state, hlc, at };
 }
 
-export async function gcEvents(snapshotHlc) {
+export async function gcEvents(key, snapshotHlc) {
   const db = await openStore();
   const all = await db.getAll(EVENTS_STORE);
   const tx = db.transaction(EVENTS_STORE, 'readwrite');
   for (const event of all) {
-    if (compareHlc(event.hlc, snapshotHlc) <= 0) tx.store.delete(event.id);
+    if (eventMatchesSnapshotScope(key, event) && compareHlc(event.hlc, snapshotHlc) <= 0) tx.store.delete(event.id);
   }
   await tx.done;
 }
@@ -68,18 +74,17 @@ export async function hydrateFromSnapshot(key, events) {
 async function shouldTakeSnapshot(key) {
   const db = await openStore();
   const snapshot = await loadSnapshot(key);
+  const scopedEvents = (await db.getAll(EVENTS_STORE)).filter((event) => eventMatchesSnapshotScope(key, event));
 
   if (snapshot) {
     const age = Date.now() - new Date(snapshot.at).getTime();
     if (age >= SNAPSHOT_AGE_MS) return { should: true, reason: 'age' };
-    const all = await db.getAll(EVENTS_STORE);
-    const since = all.filter(e => compareHlc(e.hlc, snapshot.hlc) > 0).length;
+    const since = scopedEvents.filter(e => compareHlc(e.hlc, snapshot.hlc) > 0).length;
     if (since >= SNAPSHOT_EVENT_THRESHOLD) return { should: true, reason: 'count' };
     return { should: false };
   }
 
-  const all = await db.getAll(EVENTS_STORE);
-  if (all.length >= SNAPSHOT_EVENT_THRESHOLD) return { should: true, reason: 'count' };
+  if (scopedEvents.length >= SNAPSHOT_EVENT_THRESHOLD) return { should: true, reason: 'count' };
   return { should: false };
 }
 
@@ -92,7 +97,7 @@ export function checkAndScheduleSnapshot(key, state, hlc) {
       const { should } = await shouldTakeSnapshot(key);
       if (!should) return;
       await saveSnapshot(key, state, hlc);
-      await gcEvents(hlc);
+      await gcEvents(key, hlc);
       if (_afterSnapshotSaved) await _afterSnapshotSaved(key, state, hlc);
     } catch (err) {
       if (err?.code !== 11) console.error('[Kanvana] Snapshot failed', err);

--- a/client/src/modules/render.js
+++ b/client/src/modules/render.js
@@ -10,6 +10,7 @@ import { on, DATA_CHANGED } from './events.js';
 import { createTaskElement, formatDisplayDate } from './task-card.js';
 import { createColumnElement, closeAllColumnMenus, initColumnMenuCloseHandler } from './column-element.js';
 import { renderSwimlaneBoard } from './swimlane-renderer.js';
+import { formatWipCount, syncColumnWip } from './wip-limit.js';
 
 // Depth of the current drag-reconcile window. While open (> 0), a projected
 // DATA_CHANGED patches the board in place via reconcileBoard() instead of the
@@ -123,7 +124,7 @@ function renderStandardBoard(container, sortedColumns, visibleTasks, settings, l
       tasksList.appendChild(buildShowMoreButton(columnTasks.length - doneVisibleCount));
     }
 
-    taskCounter.textContent = columnTasks.length;
+    syncColumnWip(columnEl, columnTasks.length, column);
   });
 }
 
@@ -145,14 +146,16 @@ function updateColumnSelect() {
  */
 export function syncCollapsedTitles(tasksCache) {
   const tasks = tasksCache || loadTasks();
+  const columns = loadColumns();
   document.querySelectorAll('.task-column.is-collapsed').forEach(columnEl => {
     const columnId = columnEl.dataset.column;
     const h2 = columnEl.querySelector('h2');
     if (!columnId || !h2) return;
 
+    const column = columns.find((c) => c.id === columnId);
     const taskCount = tasks.filter(t => t.column === columnId).length;
-    const columnName = h2.textContent.replace(/\s*\(\d+\)$/, '');
-    h2.textContent = `${columnName} (${taskCount})`;
+    const columnName = h2.textContent.replace(/\s*\(\d+(?:\/\d+)?\)$/, '');
+    h2.textContent = `${columnName} (${formatWipCount(taskCount, column)})`;
   });
 }
 
@@ -283,8 +286,7 @@ export function reconcileBoard() {
       tasksList.appendChild(buildShowMoreButton(columnTasks.length - doneVisibleCount));
     }
 
-    const taskCounter = columnEl.querySelector('.task-counter');
-    if (taskCounter) taskCounter.textContent = columnTasks.length;
+    syncColumnWip(columnEl, columnTasks.length, column);
   });
 
   existingCards.forEach((el, id) => {

--- a/client/src/modules/schema.js
+++ b/client/src/modules/schema.js
@@ -61,6 +61,8 @@ export function createColumn(overrides = {}) {
     color: DEFAULT_COLUMN_COLOR,
     order: 0,
     collapsed: false,
+    // 0 = unlimited. Advisory only — never blocks a task entering the column.
+    wipLimit: 0,
     // role: 'done' marks the terminal Done column; absent for regular columns.
     role: '',
     deleted: false,

--- a/client/src/modules/storage.js
+++ b/client/src/modules/storage.js
@@ -540,6 +540,25 @@ function saveBoards(boards) {
   schedulePersist(BOARDS_KEY, boards);
 }
 
+export function mergeBoardsFromRemote(remoteBoards) {
+  const incoming = Array.isArray(remoteBoards) ? remoteBoards : [];
+  if (incoming.length === 0) return listBoards();
+
+  const merged = new Map((state.boards || []).map((board) => [board.id, board]));
+  for (const board of incoming) {
+    if (!board || typeof board.id !== 'string') continue;
+    merged.set(board.id, {
+      ...merged.get(board.id),
+      ...board,
+      name: typeof board.name === 'string' ? board.name : merged.get(board.id)?.name || 'Untitled board'
+    });
+  }
+
+  const nextBoards = [...merged.values()];
+  saveBoards(nextBoards);
+  return listBoards();
+}
+
 export function getActiveBoardId() {
   const boards = listBoards();
   const stored = state.activeBoardId;

--- a/client/src/modules/swimlane-renderer.js
+++ b/client/src/modules/swimlane-renderer.js
@@ -16,6 +16,13 @@ import { createTaskElement } from './task-card.js';
 import { emit, DATA_CHANGED } from './events.js';
 import { isDoneColumn as isPermanentDoneColumn } from './constants.js';
 import { h, cx } from './dom.js';
+import { applyWipCounter, getWipState } from './wip-limit.js';
+
+function buildSwimlaneCounter(column, taskCount) {
+  const counter = h('span', { class: 'task-counter', 'data-column-id': column.id });
+  applyWipCounter(counter, taskCount, column);
+  return counter;
+}
 
 export function createSwimlaneHeaderCell(column, taskCount) {
   const isCollapsed = column?.collapsed === true;
@@ -33,11 +40,12 @@ export function createSwimlaneHeaderCell(column, taskCount) {
   return h('section', {
     class: cx('swimlane-column-header', isCollapsed && 'is-collapsed'),
     'data-column': column.id,
+    'data-wip': getWipState(taskCount, column),
     style: column?.color ? { '--column-accent': column.color } : {}
   },
     collapseBtn,
     !isCollapsed ? h('h2', {}, column.name) : null,
-    !isCollapsed ? h('span', { class: 'task-counter', 'data-column-id': column.id, 'aria-label': 'Task count' }, String(taskCount)) : null,
+    !isCollapsed ? buildSwimlaneCounter(column, taskCount) : null,
     !isCollapsed ? h('button', {
       class: 'add-task-btn-icon', type: 'button',
       'aria-label': `Add task to ${column.name}`, title: 'Add task',

--- a/client/src/modules/sync.js
+++ b/client/src/modules/sync.js
@@ -12,6 +12,7 @@ import {
   saveTasksForBoard,
   saveLabelsForBoard,
   saveSettingsForBoard,
+  mergeBoardsFromRemote,
   getBoardById,
   setActiveBoardId,
   getActiveBoardId,
@@ -420,11 +421,12 @@ export async function pullAllBoards() {
     localBoards.push({ id: boardLocalId, name: boardRec.name });
   }
 
-  const pulledIds = localBoards.map(b => b.id);
+  const mergedBoards = mergeBoardsFromRemote(localBoards);
+  const pulledIds = mergedBoards.map(b => b.id);
   if (!activeId || !pulledIds.includes(activeId)) {
-    setActiveBoardId(localBoards[0].id);
+    setActiveBoardId(mergedBoards[0].id);
   }
 
   saveSyncMap(syncMap);
-  return localBoards;
+  return mergedBoards;
 }

--- a/client/src/modules/wip-limit.js
+++ b/client/src/modules/wip-limit.js
@@ -1,0 +1,70 @@
+import { isDoneColumn } from './constants.js';
+
+export const MAX_WIP_LIMIT = 999;
+
+export function normalizeWipLimit(value) {
+  const parsed = typeof value === 'number' ? value : Number.parseInt(String(value ?? '').trim(), 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) return 0;
+  return Math.min(Math.floor(parsed), MAX_WIP_LIMIT);
+}
+
+// Done is terminal and unbounded — a limit there would block finishing work.
+export function getWipLimit(column) {
+  if (!column || isDoneColumn(column)) return 0;
+  return normalizeWipLimit(column.wipLimit);
+}
+
+export function getWipState(count, column) {
+  const limit = getWipLimit(column);
+  if (!limit) return 'under';
+  if (count > limit) return 'over';
+  if (count === limit) return 'at';
+  return 'under';
+}
+
+export function formatWipCount(count, column) {
+  const limit = getWipLimit(column);
+  return limit ? `${count}/${limit}` : String(count);
+}
+
+export function wipCounterLabel(count, column) {
+  const limit = getWipLimit(column);
+  if (!limit) return `${count} tasks`;
+  const state = getWipState(count, column);
+  const suffix = state === 'over' ? ', over limit' : state === 'at' ? ', at limit' : '';
+  return `${count} of ${limit} tasks${suffix}`;
+}
+
+function pulseCounter(counterEl) {
+  if (!counterEl) return;
+  counterEl.classList.remove('wip-pulse');
+  // Force reflow so re-adding the class restarts the animation.
+  void counterEl.offsetWidth;
+  counterEl.classList.add('wip-pulse');
+  counterEl.addEventListener('animationend', () => counterEl.classList.remove('wip-pulse'), { once: true });
+}
+
+export function applyWipCounter(counterEl, count, column) {
+  if (!counterEl) return;
+  const limit = getWipLimit(column);
+  counterEl.textContent = String(count);
+  if (limit) {
+    const limitEl = document.createElement('span');
+    limitEl.className = 'wip-limit';
+    limitEl.textContent = `/${limit}`;
+    counterEl.appendChild(limitEl);
+  }
+  counterEl.setAttribute('aria-label', wipCounterLabel(count, column));
+}
+
+export function syncColumnWip(columnEl, count, column) {
+  if (!columnEl) return;
+  const counterEl = columnEl.querySelector('.task-counter');
+  applyWipCounter(counterEl, count, column);
+
+  const next = getWipState(count, column);
+  const prev = columnEl.getAttribute('data-wip');
+  if (prev === next) return;
+  columnEl.setAttribute('data-wip', next);
+  if (prev && prev !== 'over' && next === 'over') pulseCounter(counterEl);
+}

--- a/client/src/styles/components/auth.css
+++ b/client/src/styles/components/auth.css
@@ -118,3 +118,8 @@
 .btn-text:hover {
   opacity: 0.8;
 }
+
+.session-status #login-btn,
+.session-status .user-info {
+  flex-shrink: 1;
+}

--- a/client/src/styles/components/column.css
+++ b/client/src/styles/components/column.css
@@ -102,12 +102,70 @@ body.dragging-column .column-header * {
   justify-content: center;
   background-color: var(--surface-muted);
   color: var(--text-muted);
-  border-radius: 50%;
-  width: 26px;
+  /* Pill, not circle: min-width keeps an unlimited column's bare count a circle
+     while "6/5" is free to grow. */
+  border-radius: 999px;
+  min-width: 26px;
+  width: auto;
+  padding: 0 7px;
   height: 26px;
+  box-sizing: border-box;
   font-size: 12px;
   font-weight: 700;
   flex-shrink: 0;
+  transition: background-color var(--transition-fast), color var(--transition-fast);
+}
+
+/* The count is the number you act on; the limit is a denominator you read once. */
+.task-counter .wip-limit {
+  font-weight: 500;
+  opacity: 0.55;
+}
+
+/* ── WIP limit states ──────────────────────────────────────────────────────
+   At limit is healthy operation, so it colours the counter and draws a top
+   edge but never tints the column. Only a breach earns the tint — the two
+   states differ in kind, not just hue, so they survive greyscale. */
+
+[data-wip="at"] .task-counter {
+  background-color: var(--color-warning-bg);
+  color: var(--color-warning-fg);
+}
+
+[data-wip="over"] .task-counter {
+  background-color: var(--color-danger);
+  color: #ffffff;
+}
+
+[data-wip="over"] .task-counter .wip-limit {
+  opacity: 0.7;
+}
+
+.task-column[data-wip="at"],
+.swimlane-column-header[data-wip="at"] {
+  box-shadow: inset 0 2px 0 0 var(--color-warning);
+}
+
+.task-column[data-wip="over"],
+.swimlane-column-header[data-wip="over"] {
+  box-shadow: inset 0 2px 0 0 var(--color-danger);
+}
+
+.task-column[data-wip="over"] .column-header,
+.swimlane-column-header[data-wip="over"] {
+  background-color: var(--color-danger-bg);
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .task-counter.wip-pulse {
+    animation: wip-pulse 180ms ease-out;
+  }
+}
+
+@keyframes wip-pulse {
+  0% { transform: scale(1); }
+  50% { transform: scale(1.12); }
+  100% { transform: scale(1); }
 }
 
 /* Column actions */

--- a/client/src/styles/components/forms.css
+++ b/client/src/styles/components/forms.css
@@ -53,6 +53,14 @@ fieldset.form-group legend {
   min-height: 60px;
 }
 
+.form-hint {
+  display: block;
+  margin-top: 6px;
+  font-size: 12px;
+  line-height: 1.45;
+  color: var(--text-muted);
+}
+
 /* Live link preview strip below description textarea */
 .description-links {
   display: flex;

--- a/client/src/styles/layout.css
+++ b/client/src/styles/layout.css
@@ -139,6 +139,10 @@
   display: flex;
 }
 
+.controls-menu-mobile-header {
+  display: none;
+}
+
 /* Menu items style in dropdown */
 .controls-actions .control-btn {
   width: 100%;

--- a/client/src/styles/layout.css
+++ b/client/src/styles/layout.css
@@ -89,6 +89,18 @@
   color: var(--color-primary);
 }
 
+.session-status {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.toolbar-quick-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
 .settings-section {
   margin-top: 20px;
   padding-top: 18px;

--- a/client/src/styles/responsive.css
+++ b/client/src/styles/responsive.css
@@ -23,21 +23,22 @@
     overflow: hidden;
   }
 
-  /* Mobile header: brand left, menu button right, search below */
+  /* Mobile header: keep one row and open search as an overlay */
   .controls {
     display: grid;
-    grid-template-columns: 1fr auto auto;
-    grid-template-rows: auto auto;
+    grid-template-columns: minmax(0, 1fr) auto;
     gap: 8px;
-    padding: 8px;
+    padding: 8px 10px;
     flex-wrap: nowrap;
+    align-items: center;
   }
 
   .brand {
     grid-column: 1;
-    grid-row: 1;
     margin-right: 0;
-    font-size: 16px;
+    min-width: 0;
+    gap: 8px;
+    font-size: 14px;
     overflow: hidden;
   }
 
@@ -45,24 +46,103 @@
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
-    max-width: 200px;
+    max-width: none;
+    font-size: 13px;
+    line-height: 1.15;
   }
 
-  #notifications-quick-btn {
+  .toolbar-quick-actions {
     grid-column: 2;
-    grid-row: 1;
+    gap: 6px;
     margin-left: auto;
   }
 
-  #desktop-menu-btn {
-    grid-column: 3;
-    grid-row: 1;
+  .board-search {
+    position: absolute;
+    top: calc(100% + 6px);
+    left: 10px;
+    right: 10px;
+    z-index: 260;
+    flex: none;
+    opacity: 0;
+    pointer-events: none;
+    transform: translateY(-8px);
+    transition: opacity var(--transition-fast), transform var(--transition-fast);
+    box-shadow: 0 14px 36px rgba(15, 23, 42, 0.18);
   }
 
-  .board-search {
-    grid-column: 1 / -1;
-    grid-row: 2;
-    flex: none;
+  .session-status {
+    position: absolute;
+    top: calc(100% + 52px);
+    left: 10px;
+    right: 10px;
+    z-index: 259;
+    justify-content: space-between;
+    padding: 8px 10px;
+    border: 1px solid var(--border);
+    border-radius: 14px;
+    background: color-mix(in srgb, var(--surface) 94%, transparent);
+    backdrop-filter: blur(10px);
+    opacity: 0;
+    pointer-events: none;
+    transform: translateY(-8px);
+    transition: opacity var(--transition-fast), transform var(--transition-fast);
+  }
+
+  .controls.mobile-menu-open .board-search,
+  .controls.mobile-menu-open .session-status,
+  .board-search:focus-within {
+    opacity: 1;
+    pointer-events: auto;
+    transform: translateY(0);
+  }
+
+  #notifications-quick-btn,
+  #desktop-menu-btn {
+    padding: 8px;
+    min-width: 38px;
+    min-height: 38px;
+    justify-content: center;
+  }
+
+  #notifications-quick-btn {
+    margin-left: 0;
+  }
+
+  .session-status #login-btn {
+    padding: 6px 8px;
+    font-size: 12px;
+    gap: 4px;
+    white-space: nowrap;
+  }
+
+  .session-status .user-info {
+    gap: 6px;
+    padding: 0;
+    border: 0;
+    background: transparent;
+    min-width: 0;
+  }
+
+  .session-status .user-name {
+    max-width: 72px;
+    font-size: 12px;
+  }
+
+  .session-status #logout-btn {
+    padding: 6px;
+  }
+
+  .session-status .sync-indicator {
+    padding: 4px 8px;
+    font-size: 11px;
+  }
+
+  .controls-actions {
+    top: calc(100% + 100px);
+    left: 10px;
+    right: 10px;
+    max-width: none;
   }
 
   /* Scrollable columns horizontally with snap */
@@ -167,10 +247,8 @@
     gap: 6px;
   }
 
-  /* Hide the search row in landscape to save vertical space */
+  /* Keep the mobile overlay search compact in landscape */
   .board-search {
-    grid-row: 1;
-    grid-column: 1;
     max-width: 220px;
   }
 

--- a/client/src/styles/responsive.css
+++ b/client/src/styles/responsive.css
@@ -23,6 +23,10 @@
     overflow: hidden;
   }
 
+  body.mobile-menu-open {
+    overflow: hidden;
+  }
+
   /* Mobile header: keep one row and open search as an overlay */
   .controls {
     display: grid;
@@ -58,11 +62,11 @@
   }
 
   .board-search {
-    position: absolute;
-    top: calc(100% + 6px);
-    left: 10px;
-    right: 10px;
-    z-index: 260;
+    position: fixed;
+    top: calc(env(safe-area-inset-top) + 78px);
+    left: 16px;
+    right: 16px;
+    z-index: 361;
     flex: none;
     opacity: 0;
     pointer-events: none;
@@ -72,11 +76,11 @@
   }
 
   .session-status {
-    position: absolute;
-    top: calc(100% + 52px);
-    left: 10px;
-    right: 10px;
-    z-index: 259;
+    position: fixed;
+    top: calc(env(safe-area-inset-top) + 130px);
+    left: 16px;
+    right: 16px;
+    z-index: 361;
     justify-content: space-between;
     padding: 8px 10px;
     border: 1px solid var(--border);
@@ -139,10 +143,74 @@
   }
 
   .controls-actions {
-    top: calc(100% + 100px);
-    left: 10px;
-    right: 10px;
+    position: fixed;
+    inset: 0;
+    z-index: 360;
     max-width: none;
+    min-width: 0;
+    padding: calc(env(safe-area-inset-top) + 18px) 16px calc(env(safe-area-inset-bottom) + 24px);
+    padding-top: calc(env(safe-area-inset-top) + 190px);
+    border: 0;
+    border-radius: 0;
+    box-shadow: none;
+    background:
+      radial-gradient(circle at top left, rgba(59, 130, 246, 0.18), transparent 36%),
+      linear-gradient(180deg, color-mix(in srgb, var(--surface) 94%, #0f172a 6%) 0%, var(--surface) 100%);
+    overflow-y: auto;
+    overflow-x: hidden;
+    overscroll-behavior: contain;
+    gap: 10px;
+  }
+
+  .controls-menu-mobile-header {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    z-index: 362;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: calc(env(safe-area-inset-top) + 18px) 16px 14px;
+    background: linear-gradient(180deg, var(--surface) 0%, color-mix(in srgb, var(--surface) 82%, transparent) 100%);
+    border-bottom: 1px solid var(--border-subtle);
+    backdrop-filter: blur(14px);
+  }
+
+  .controls-menu-mobile-title {
+    font-size: 18px;
+    font-weight: 700;
+    color: var(--text);
+    letter-spacing: 0.01em;
+  }
+
+  .controls-menu-close-btn {
+    width: 44px;
+    height: 44px;
+    border-radius: 12px;
+    opacity: 1;
+    background: var(--surface-muted);
+    color: var(--text);
+    border: 1px solid var(--border);
+  }
+
+  .controls-menu-close-btn:hover {
+    background: var(--surface-alt);
+  }
+
+  .controls-actions .control-btn,
+  .controls-actions .control-select {
+    min-height: 48px;
+    border-radius: 12px;
+  }
+
+  .controls-actions .control-btn {
+    font-size: 15px;
+  }
+
+  .controls-actions .legal-menu-link {
+    min-height: 48px;
+    border-radius: 12px;
   }
 
   /* Scrollable columns horizontally with snap */
@@ -249,7 +317,7 @@
 
   /* Keep the mobile overlay search compact in landscape */
   .board-search {
-    max-width: 220px;
+    max-width: none;
   }
 
   .brand {

--- a/client/src/styles/tokens.css
+++ b/client/src/styles/tokens.css
@@ -12,6 +12,8 @@
   --color-danger-bg: #fee2e2;
   --color-success: #16a34a;
   --color-warning: #f59e0b;
+  --color-warning-bg: #fef3c7;
+  --color-warning-fg: #78350f;
 
   /* Surface colors */
   --app-bg: #f3f4f6;
@@ -84,6 +86,8 @@
   --btn-small-bg: #111827;
   --btn-small-hover-bg: #1f2937;
   --color-danger-bg: rgba(220, 38, 38, 0.15);
+  --color-warning-bg: rgba(245, 158, 11, 0.18);
+  --color-warning-fg: #fcd34d;
 
   /* Priority badge colors – brighter for dark surfaces */
   --priority-high-fg: #f87171;

--- a/client/tests/dom/wip-limit.test.js
+++ b/client/tests/dom/wip-limit.test.js
@@ -1,0 +1,90 @@
+import { describe, expect, test } from 'vitest';
+import { applyWipCounter, syncColumnWip } from '../../src/modules/wip-limit.js';
+import { mountToBody } from './setup.js';
+
+const todo = { id: 'c1', name: 'Todo', wipLimit: 5 };
+const unlimited = { id: 'c2', name: 'Backlog', wipLimit: 0 };
+
+function buildColumn() {
+  const el = document.createElement('article');
+  el.className = 'task-column';
+  el.dataset.column = 'c1';
+  const counter = document.createElement('span');
+  counter.className = 'task-counter';
+  el.appendChild(counter);
+  mountToBody(el);
+  return el;
+}
+
+describe('applyWipCounter', () => {
+  test('renders a bare count for an unlimited column', () => {
+    const counter = document.createElement('span');
+    applyWipCounter(counter, 3, unlimited);
+    expect(counter.textContent).toBe('3');
+    expect(counter.querySelector('.wip-limit')).toBeNull();
+    expect(counter.getAttribute('aria-label')).toBe('3 tasks');
+  });
+
+  test('renders count with the limit in its own span', () => {
+    const counter = document.createElement('span');
+    applyWipCounter(counter, 3, todo);
+    expect(counter.textContent).toBe('3/5');
+    expect(counter.querySelector('.wip-limit')?.textContent).toBe('/5');
+    expect(counter.getAttribute('aria-label')).toBe('3 of 5 tasks');
+  });
+
+  test('re-applying replaces rather than appends', () => {
+    const counter = document.createElement('span');
+    applyWipCounter(counter, 3, todo);
+    applyWipCounter(counter, 4, todo);
+    expect(counter.textContent).toBe('4/5');
+    expect(counter.querySelectorAll('.wip-limit')).toHaveLength(1);
+  });
+});
+
+describe('syncColumnWip', () => {
+  test('drives data-wip through under, at and over', () => {
+    const el = buildColumn();
+
+    syncColumnWip(el, 4, todo);
+    expect(el.dataset.wip).toBe('under');
+
+    syncColumnWip(el, 5, todo);
+    expect(el.dataset.wip).toBe('at');
+
+    syncColumnWip(el, 6, todo);
+    expect(el.dataset.wip).toBe('over');
+  });
+
+  test('pulses only on the transition into over-limit', () => {
+    const el = buildColumn();
+    const counter = el.querySelector('.task-counter');
+
+    // First paint must not pulse, even if it lands over the limit.
+    syncColumnWip(el, 6, todo);
+    expect(counter.classList.contains('wip-pulse')).toBe(false);
+
+    syncColumnWip(el, 5, todo);
+    syncColumnWip(el, 6, todo);
+    expect(counter.classList.contains('wip-pulse')).toBe(true);
+  });
+
+  test('staying over-limit does not re-pulse', () => {
+    const el = buildColumn();
+    const counter = el.querySelector('.task-counter');
+
+    syncColumnWip(el, 5, todo);
+    syncColumnWip(el, 6, todo);
+    counter.classList.remove('wip-pulse');
+    syncColumnWip(el, 7, todo);
+    expect(counter.classList.contains('wip-pulse')).toBe(false);
+    expect(counter.textContent).toBe('7/5');
+  });
+
+  test('an unlimited column stays under at any count', () => {
+    const el = buildColumn();
+    syncColumnWip(el, 200, unlimited);
+    expect(el.dataset.wip).toBe('under');
+    expect(el.querySelector('.task-counter').textContent).toBe('200');
+  });
+});

--- a/client/tests/e2e/wip-limit.spec.ts
+++ b/client/tests/e2e/wip-limit.spec.ts
@@ -1,0 +1,86 @@
+import { test, expect, type Page } from '@playwright/test';
+
+function columnByName(page: Page, name: string) {
+  return page.locator('article.task-column').filter({ has: page.locator('h2', { hasText: name }) });
+}
+
+async function setWipLimit(page: Page, columnName: string, limit: number) {
+  const column = columnByName(page, columnName);
+  await column.getByRole('button', { name: `${columnName} column menu` }).click();
+  await column.getByRole('menuitem', { name: 'Edit', exact: true }).click();
+
+  const modal = page.locator('#column-modal');
+  await expect(modal).toBeVisible();
+  await modal.locator('#column-wip-limit').fill(String(limit));
+  await modal.getByRole('button', { name: 'Save Changes' }).click();
+  await expect(modal).toBeHidden();
+}
+
+async function addTask(page: Page, columnName: string, title: string) {
+  await page.getByRole('button', { name: `Add task to ${columnName}` }).click();
+  const modal = page.locator('#task-modal');
+  await expect(modal).toBeVisible();
+  await modal.locator('#task-title').fill(title);
+  await modal.getByRole('button', { name: 'Add Task', exact: true }).click();
+  await expect(modal).toBeHidden();
+}
+
+test.describe('WIP limits', () => {
+  test.describe.configure({ mode: 'serial' });
+
+  test('a regular column exposes a WIP limit field defaulting to unlimited', async ({ page }) => {
+    await page.goto('/');
+    const column = columnByName(page, 'To Do');
+    await column.getByRole('button', { name: 'To Do column menu' }).click();
+    await column.getByRole('menuitem', { name: 'Edit', exact: true }).click();
+
+    const modal = page.locator('#column-modal');
+    await expect(modal).toBeVisible();
+    await expect(page.locator('#column-wip-limit-group')).toBeVisible();
+    await expect(modal.locator('#column-wip-limit')).toHaveValue('0');
+  });
+
+  test('the Done column hides the WIP limit field', async ({ page }) => {
+    await page.goto('/');
+    const done = columnByName(page, 'Done');
+    await done.getByRole('button', { name: 'Done column menu' }).click();
+    await done.getByRole('menuitem', { name: 'Edit', exact: true }).click();
+
+    await expect(page.locator('#column-modal')).toBeVisible();
+    await expect(page.locator('#column-wip-limit-group')).toBeHidden();
+  });
+
+  test('counter shows count/limit and escalates under → at → over', async ({ page }) => {
+    await page.goto('/');
+    await setWipLimit(page, 'To Do', 2);
+
+    const column = columnByName(page, 'To Do');
+    const counter = column.locator('.task-counter');
+
+    await expect(column).toHaveAttribute('data-wip', 'under');
+    await expect(counter).toContainText('/2');
+
+    const start = Number((await counter.textContent())?.split('/')[0] ?? 0);
+    for (let i = start; i < 2; i += 1) {
+      await addTask(page, 'To Do', `WIP task ${i + 1}`);
+    }
+
+    await expect(column).toHaveAttribute('data-wip', 'at');
+    await expect(counter).toHaveText('2/2');
+
+    await addTask(page, 'To Do', 'WIP task overflow');
+
+    // Advisory only: the task is created even though the column is full.
+    await expect(column).toHaveAttribute('data-wip', 'over');
+    await expect(counter).toHaveText('3/2');
+    await expect(page.getByRole('listitem', { name: /Task: WIP task overflow/i })).toBeVisible();
+  });
+
+  test('the limit survives a reload', async ({ page }) => {
+    await page.goto('/');
+    await setWipLimit(page, 'To Do', 7);
+
+    await page.reload();
+    await expect(columnByName(page, 'To Do').locator('.task-counter')).toContainText('/7');
+  });
+});

--- a/client/tests/unit/columns.test.js
+++ b/client/tests/unit/columns.test.js
@@ -143,3 +143,51 @@ test('deleteColumn deletes tasks in the column', () => {
   const deletedTasks = loadDeletedTasksForBoard(getActiveBoardId());
   expect(deletedTasks.some(t => t.id === 't1')).toBe(false);
 });
+
+// ── WIP limits ──────────────────────────────────────────────────────
+
+test('addColumn defaults to an unlimited WIP limit', () => {
+  addColumn('No Limit', '#ff0000');
+  const col = loadColumns().find(c => c.name === 'No Limit');
+  expect(col.wipLimit).toBe(0);
+});
+
+test('addColumn stores and normalizes a WIP limit', () => {
+  addColumn('Limited', '#ff0000', '5');
+  expect(loadColumns().find(c => c.name === 'Limited').wipLimit).toBe(5);
+
+  addColumn('Junk', '#ff0000', -4);
+  expect(loadColumns().find(c => c.name === 'Junk').wipLimit).toBe(0);
+});
+
+test('updateColumn persists a WIP limit change', () => {
+  addColumn('Doing', '#ff0000', 3);
+  const id = loadColumns().find(c => c.name === 'Doing').id;
+
+  updateColumn(id, 'Doing', '#ff0000', 8);
+  expect(loadColumns().find(c => c.id === id).wipLimit).toBe(8);
+});
+
+test('updateColumn accepts a limit below the current task count', () => {
+  addColumn('Doing', '#ff0000', 10);
+  const id = loadColumns().find(c => c.name === 'Doing').id;
+  saveTasks([
+    { id: 'a', title: 'a', column: id, order: 1 },
+    { id: 'b', title: 'b', column: id, order: 2 },
+    { id: 'c', title: 'c', column: id, order: 3 }
+  ]);
+
+  updateColumn(id, 'Doing', '#ff0000', 1);
+  expect(loadColumns().find(c => c.id === id).wipLimit).toBe(1);
+  expect(loadTasks().filter(t => t.column === id)).toHaveLength(3);
+});
+
+test('omitting the WIP limit on updateColumn preserves the existing one', () => {
+  addColumn('Doing', '#ff0000', 3);
+  const id = loadColumns().find(c => c.name === 'Doing').id;
+
+  updateColumn(id, 'Doing', '#00ff00');
+  const col = loadColumns().find(c => c.id === id);
+  expect(col.wipLimit).toBe(3);
+  expect(col.color).toBe('#00ff00');
+});

--- a/client/tests/unit/event-sourcing/snapshot.test.js
+++ b/client/tests/unit/event-sourcing/snapshot.test.js
@@ -73,10 +73,26 @@ test('gcEvents removes events at or before snapshotHlc and leaves later ones', a
   ];
   for (const ev of eventsToWrite) await db.put('events', { ...ev, synced: false });
 
-  await gcEvents(makeHlc(200));
+  await gcEvents('board-a', makeHlc(200));
 
   const remaining = await db.getAll('events');
   expect(remaining.map(e => e.id)).toEqual(['e3']);
+});
+
+test('gcEvents for a board snapshot does not delete unrelated boards\' events', async () => {
+  const db = await openStore();
+  const eventsToWrite = [
+    makeEvent('a1', 'board.created', makeHlc(100), 'board-a', 'board-a'),
+    makeEvent('a2', 'task.updated', makeHlc(200), 'board-a', 'task-a'),
+    makeEvent('b1', 'board.created', makeHlc(150), 'board-b', 'board-b'),
+    makeEvent('b2', 'task.updated', makeHlc(180), 'board-b', 'task-b')
+  ];
+  for (const ev of eventsToWrite) await db.put('events', { ...ev, synced: false });
+
+  await gcEvents('board-a', makeHlc(200));
+
+  const remaining = await db.getAll('events');
+  expect(remaining.map(e => e.id)).toEqual(['b1', 'b2']);
 });
 
 // ── Hydration ──────────────────────────────────────────────────────────────────
@@ -148,6 +164,20 @@ test('checkAndScheduleSnapshot does not schedule when event count is below thres
   expect(await loadSnapshot('board-a')).toBeNull();
 });
 
+test('checkAndScheduleSnapshot ignores other boards when counting events', async () => {
+  _setJitterForTesting(() => 0);
+  const db = await openStore();
+  for (let i = 0; i < SNAPSHOT_EVENT_THRESHOLD; i++) {
+    await db.put('events', { ...makeEvent(`b${i}`, 'task.updated', makeHlc(i + 1), 'board-b', `task-${i}`), synced: false });
+  }
+
+  const state = createProjectionState({ tasks: [{ id: 'task-1', title: 'T', column: 'todo', columnHistory: [] }] });
+  checkAndScheduleSnapshot('board-a', state, makeHlc(SNAPSHOT_EVENT_THRESHOLD + 1));
+  await settle();
+
+  expect(await loadSnapshot('board-a')).toBeNull();
+});
+
 test('checkAndScheduleSnapshot schedules when snapshot age exceeds 14 days', async () => {
   _setJitterForTesting(() => 0);
   const oldAt = new Date(Date.now() - SNAPSHOT_AGE_MS - 1).toISOString();
@@ -196,7 +226,7 @@ test('rehydration after GC produces the same projection as before GC', async () 
   const preGcProjection = applyEvents(createProjectionState(), events);
   await saveSnapshot('board-a', preGcProjection, makeHlc(300));
 
-  await gcEvents(makeHlc(300));
+  await gcEvents('board-a', makeHlc(300));
 
   const remaining = await db.getAll('events');
   expect(remaining).toHaveLength(0);

--- a/client/tests/unit/sync.test.js
+++ b/client/tests/unit/sync.test.js
@@ -43,6 +43,7 @@ vi.mock('../../src/modules/storage.js', () => ({
   saveTasksForBoard: vi.fn(),
   saveLabelsForBoard: vi.fn(),
   saveSettingsForBoard: vi.fn(),
+  mergeBoardsFromRemote: vi.fn((boards) => boards),
   getBoardById: vi.fn(() => null),
   setActiveBoardId: vi.fn(),
   getActiveBoardId: vi.fn(() => null),
@@ -72,6 +73,7 @@ import {
   saveTasksForBoard,
   saveLabelsForBoard,
   saveSettingsForBoard,
+  mergeBoardsFromRemote,
   getBoardById,
   setActiveBoardId,
   getActiveBoardId,
@@ -341,6 +343,27 @@ describe('pullAllBoards', () => {
     expect(saveTasksForBoard).toHaveBeenCalledWith('b1', []);
     expect(saveLabelsForBoard).toHaveBeenCalledWith('b1', []);
     expect(saveSettingsForBoard).toHaveBeenCalledWith('b1', {});
+  });
+
+  it('merges pulled boards into the local board list so all remote boards become visible', async () => {
+    mockAuthStore.token = 'tok';
+    mockAuthStore.record = { id: 'user1' };
+    mockAuthStore.isValid = true;
+
+    mockCollection.getFullList
+      .mockResolvedValueOnce([
+        { id: 'pb-b1', local_id: 'b1', name: 'Board 1', settings: {} },
+        { id: 'pb-b2', local_id: 'b2', name: 'Board 2', settings: {} },
+      ])
+      .mockResolvedValueOnce([]).mockResolvedValueOnce([]).mockResolvedValueOnce([]).mockResolvedValueOnce([]).mockResolvedValueOnce([])
+      .mockResolvedValueOnce([]).mockResolvedValueOnce([]).mockResolvedValueOnce([]).mockResolvedValueOnce([]).mockResolvedValueOnce([]);
+
+    await pullAllBoards();
+
+    expect(mergeBoardsFromRemote).toHaveBeenCalledWith([
+      { id: 'b1', name: 'Board 1' },
+      { id: 'b2', name: 'Board 2' },
+    ]);
   });
 
   it('maps PocketBase column IDs back to local IDs in tasks', async () => {

--- a/client/tests/unit/wip-limit.test.js
+++ b/client/tests/unit/wip-limit.test.js
@@ -1,0 +1,121 @@
+import { describe, expect, test } from 'vitest';
+import {
+  MAX_WIP_LIMIT,
+  formatWipCount,
+  getWipLimit,
+  getWipState,
+  normalizeWipLimit,
+  wipCounterLabel
+} from '../../src/modules/wip-limit.js';
+
+const todo = { id: 'c1', name: 'Todo', wipLimit: 5 };
+const unlimited = { id: 'c2', name: 'Backlog', wipLimit: 0 };
+const done = { id: 'c3', name: 'Done', role: 'done', wipLimit: 5 };
+const legacyDone = { id: 'done', name: 'Done', wipLimit: 5 };
+
+describe('normalizeWipLimit', () => {
+  test('coerces anything that is not a positive integer to unlimited', () => {
+    expect(normalizeWipLimit(undefined)).toBe(0);
+    expect(normalizeWipLimit(null)).toBe(0);
+    expect(normalizeWipLimit('')).toBe(0);
+    expect(normalizeWipLimit('abc')).toBe(0);
+    expect(normalizeWipLimit(-3)).toBe(0);
+    expect(normalizeWipLimit(0)).toBe(0);
+    expect(normalizeWipLimit(NaN)).toBe(0);
+    expect(normalizeWipLimit(Infinity)).toBe(0);
+  });
+
+  test('accepts numeric strings and floors fractions', () => {
+    expect(normalizeWipLimit('5')).toBe(5);
+    expect(normalizeWipLimit(' 12 ')).toBe(12);
+    expect(normalizeWipLimit(2.7)).toBe(2);
+  });
+
+  test('caps at MAX_WIP_LIMIT', () => {
+    expect(normalizeWipLimit(1e9)).toBe(MAX_WIP_LIMIT);
+  });
+});
+
+describe('getWipLimit', () => {
+  test('reads the column limit', () => {
+    expect(getWipLimit(todo)).toBe(5);
+    expect(getWipLimit(unlimited)).toBe(0);
+  });
+
+  test('Done is exempt in both role and legacy-id form', () => {
+    expect(getWipLimit(done)).toBe(0);
+    expect(getWipLimit(legacyDone)).toBe(0);
+  });
+
+  test('tolerates a missing column', () => {
+    expect(getWipLimit(null)).toBe(0);
+    expect(getWipLimit({})).toBe(0);
+  });
+});
+
+describe('getWipState', () => {
+  test('under below the limit', () => {
+    expect(getWipState(0, todo)).toBe('under');
+    expect(getWipState(4, todo)).toBe('under');
+  });
+
+  test('at exactly the limit', () => {
+    expect(getWipState(5, todo)).toBe('at');
+  });
+
+  test('over above the limit', () => {
+    expect(getWipState(6, todo)).toBe('over');
+    expect(getWipState(50, todo)).toBe('over');
+  });
+
+  test('an unlimited or Done column is never at or over', () => {
+    expect(getWipState(999, unlimited)).toBe('under');
+    expect(getWipState(999, done)).toBe('under');
+  });
+});
+
+describe('formatWipCount', () => {
+  test('shows the bare count when unlimited', () => {
+    expect(formatWipCount(3, unlimited)).toBe('3');
+    expect(formatWipCount(3, done)).toBe('3');
+  });
+
+  test('shows count/limit when limited', () => {
+    expect(formatWipCount(3, todo)).toBe('3/5');
+    expect(formatWipCount(6, todo)).toBe('6/5');
+  });
+});
+
+describe('wipCounterLabel', () => {
+  test('carries the state without relying on colour', () => {
+    expect(wipCounterLabel(3, unlimited)).toBe('3 tasks');
+    expect(wipCounterLabel(3, todo)).toBe('3 of 5 tasks');
+    expect(wipCounterLabel(5, todo)).toBe('5 of 5 tasks, at limit');
+    expect(wipCounterLabel(6, todo)).toBe('6 of 5 tasks, over limit');
+  });
+});
+
+describe('import boundary', () => {
+  test('normalizeBoardModelIds coerces an untrusted wipLimit', async () => {
+    const { normalizeBoardModelIds } = await import('../../src/modules/board-serializer.js');
+
+    const { columns } = normalizeBoardModelIds({
+      columns: [
+        { id: 'a', name: 'Todo', wipLimit: 5 },
+        { id: 'b', name: 'Junk', wipLimit: 'not a number' },
+        { id: 'c', name: 'Negative', wipLimit: -2 },
+        { id: 'd', name: 'Huge', wipLimit: 1e9 },
+        { id: 'e', name: 'Missing' }
+      ]
+    });
+
+    const byName = Object.fromEntries(columns.map((c) => [c.name, c.wipLimit]));
+    expect(byName.Todo).toBe(5);
+    expect(byName.Junk).toBe(0);
+    expect(byName.Negative).toBe(0);
+    expect(byName.Huge).toBe(MAX_WIP_LIMIT);
+    expect(byName.Missing).toBe(0);
+    // The synthesized Done column is always unlimited.
+    expect(byName.Done).toBe(0);
+  });
+});

--- a/docs/spec/board-ui.md
+++ b/docs/spec/board-ui.md
@@ -14,6 +14,7 @@
 - Search matches task title, description, priority, label name, and label group name
 - A menu button opens controls for boards, help, labels, settings, notifications, add column, and calendar
 - A quick-access bell button mirrors the notification modal and count badge shown in the menu
+- On mobile, the top bar stays on a single row: the brand remains left, while notifications and the menu stay right; task search plus auth and sync controls move into the mobile menu overlay instead of consuming their own header rows
 
 ## Boards UI
 

--- a/docs/spec/board-ui.md
+++ b/docs/spec/board-ui.md
@@ -15,6 +15,7 @@
 - A menu button opens controls for boards, help, labels, settings, notifications, add column, and calendar
 - A quick-access bell button mirrors the notification modal and count badge shown in the menu
 - On mobile, the top bar stays on a single row: the brand remains left, while notifications and the menu stay right; task search plus auth and sync controls move into the mobile menu overlay instead of consuming their own header rows
+- On mobile, opening the controls menu expands into a full-screen overlay with a dedicated close button, keeping search, session status, and the control list within easy thumb reach
 
 ## Boards UI
 


### PR DESCRIPTION
This pull request introduces per-column Work-in-Progress (WIP) limits to the Kanban board, enhances the mobile UI for better usability, and fixes several issues related to board synchronization and event garbage collection. The main themes are new WIP limit functionality, mobile UI improvements, and bug fixes for board sync and event handling.

**WIP Limit Functionality:**

* Added per-column WIP limits: Each column now has a `wipLimit` property (0 = unlimited), settable in the Add/Edit Column modals. The column header displays `count/limit`, with color cues (amber at limit, red above), and the column top edge reflects the state. WIP limits are advisory only and never block actions due to the event-sourced sync model. The Done column is exempt, and limits apply board-wide across swimlanes. (`CHANGELOG.md`, `CONTEXT.md`, `client/src/index.html`, `client/src/modules/column-modal.js`, `client/src/modules/columns.js`, `client/src/modules/column-element.js`, `client/src/modules/board-serializer.js`) [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR10-R23) [[2]](diffhunk://#diff-86fee53c33308768d49a4ac0ff5720fd7f5411a8c8bd62ab9b80bbffa2977a14R13-R30) [[3]](diffhunk://#diff-e13bb9ab1347edb6e8fdafe64e5e05102c588e201f6c9da7c94c14caeb0bc2fbR280-R284) [[4]](diffhunk://#diff-f2cb8d6a86d3fba58dade06f08c3a77128edc3367969ba20568b6194769a5350R20-R30) [[5]](diffhunk://#diff-f2cb8d6a86d3fba58dade06f08c3a77128edc3367969ba20568b6194769a5350R122-R127) [[6]](diffhunk://#diff-ce03a4ed18a447de1d7de2edcc0bd59c67d71b1fd871e8a5903a431081086bc5R4-R14) [[7]](diffhunk://#diff-ce03a4ed18a447de1d7de2edcc0bd59c67d71b1fd871e8a5903a431081086bc5L42-R43) [[8]](diffhunk://#diff-ce03a4ed18a447de1d7de2edcc0bd59c67d71b1fd871e8a5903a431081086bc5R52-R65) [[9]](diffhunk://#diff-9d852623b3667f7da579a684a3c7cfd36b55cd7ecbc2f8be540e9b7a2213b632R10) [[10]](diffhunk://#diff-9d852623b3667f7da579a684a3c7cfd36b55cd7ecbc2f8be540e9b7a2213b632R90-R101) [[11]](diffhunk://#diff-9d852623b3667f7da579a684a3c7cfd36b55cd7ecbc2f8be540e9b7a2213b632R264) [[12]](diffhunk://#diff-e644c0007c7703856b8455ac872ee4d1c0c186da78d61f4610ed51a66ad3e724R12) [[13]](diffhunk://#diff-e644c0007c7703856b8455ac872ee4d1c0c186da78d61f4610ed51a66ad3e724R82-R90)

**Mobile UI Improvements:**

* Simplified the mobile board header into a single top row, keeping only the logo/board name, notifications, and menu visible; search and account/sync controls now open in a menu overlay. (`CHANGELOG.md`, `client/src/index.html`)
* Expanded the mobile controls menu into a full-screen overlay with an explicit close button, improving accessibility and making controls easier to find and use. (`CHANGELOG.md`, `client/src/index.html`, `client/src/kanban.js`) [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR10-R23) [[2]](diffhunk://#diff-e13bb9ab1347edb6e8fdafe64e5e05102c588e201f6c9da7c94c14caeb0bc2fbR39-R44) [[3]](diffhunk://#diff-e13bb9ab1347edb6e8fdafe64e5e05102c588e201f6c9da7c94c14caeb0bc2fbR100) [[4]](diffhunk://#diff-e13bb9ab1347edb6e8fdafe64e5e05102c588e201f6c9da7c94c14caeb0bc2fbR114-R116) [[5]](diffhunk://#diff-e13bb9ab1347edb6e8fdafe64e5e05102c588e201f6c9da7c94c14caeb0bc2fbR125) [[6]](diffhunk://#diff-0d42763137935d3fa3cd88b58d4f233e6058a598b484d6ecd03d0e005baf332fR93-R120) [[7]](diffhunk://#diff-0d42763137935d3fa3cd88b58d4f233e6058a598b484d6ecd03d0e005baf332fL115-R149)

**Bug Fixes and Sync Improvements:**

* Fixed Online Mode losing boards across devices after local snapshots by ensuring snapshots only garbage-collect events from their own board scope. (`CHANGELOG.md`, `client/src/modules/event-sourcing/snapshot.js`) [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR10-R23) [[2]](diffhunk://#diff-809beb843ec7f3076d30a30bcd23e6aa0ed6aeed33871e9645a55fa2d0ae29e9R14-R19) [[3]](diffhunk://#diff-809beb843ec7f3076d30a30bcd23e6aa0ed6aeed33871e9645a55fa2d0ae29e9L49-R60)
* Fixed the legacy full-pull sync helper so that pulled boards are merged into the local board list and are visible locally. (`CHANGELOG.md`)

These changes collectively improve workflow visibility, especially on mobile, and make board state and limits clearer without disrupting collaborative event-sourced sync.